### PR TITLE
support for Native AOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ public MessageModel<string> Get()
 }
 ```
 
+Common examples:
+
+```csharp
+MessageModel<string>.Error("message required");
+MessageModel<string>.Fail("message required");
+MessageModel<string>.Ok();
+MessageModel<string>.Ok("okk");
+MessageModel<string>.Success("data");
+```
+
 Paged return example:
 ```csharp
 [HttpGet("/page")]

--- a/README.md
+++ b/README.md
@@ -182,3 +182,36 @@ public ContentResult Page()
     };
 }
 ```
+
+## AOT (Native) publishing
+
+`MessageModel<T>` uses a custom `JsonConverter`. For AOT publishing, register the closed generic converter and provide source-generated `JsonSerializerContext` metadata for your root types.
+
+1. Register the converter at startup:
+
+```csharp
+MessageModelJsonConverterFactory.Register<WeatherForecast[]>();
+```
+
+2. Add a source-generated JSON context and include both `MessageModel<T>` and `T`:
+
+```csharp
+[JsonSerializable(typeof(MessageModel<WeatherForecast[]>))]
+[JsonSerializable(typeof(WeatherForecast[]))]
+internal partial class AppJsonContext : JsonSerializerContext
+{
+}
+```
+
+3. Configure ASP.NET Core to use the context:
+
+```csharp
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.TypeInfoResolver = AppJsonContext.Default;
+});
+```
+
+If you return additional `MessageModel<T>` types, add corresponding `Register<T>()` and `JsonSerializable` entries.
+
+You can refer to the example project `WebAppAotTest` in this repository and the [AOT support documentation](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?wt.mc_id=DT-MVP-5005195) for more information on AOT support.

--- a/README_CN.md
+++ b/README_CN.md
@@ -182,3 +182,37 @@ public ContentResult Page()
         Content = page.Render()
     };
 }
+```
+
+## AOT（Native）发布
+
+`MessageModel<T>` 使用自定义 `JsonConverter`。在 AOT 发布时，需要显式注册闭包泛型转换器，并为根类型提供源生成的 `JsonSerializerContext` 元数据。
+
+1. 启动时注册转换器：
+
+   ```csharp
+   MessageModelJsonConverterFactory.Register<WeatherForecast[]>();
+   ```
+
+2. 添加源生成 JSON 上下文，并包含 `MessageModel<T>` 与 `T`：
+
+   ```csharp
+   [JsonSerializable(typeof(MessageModel<WeatherForecast[]>))]
+   [JsonSerializable(typeof(WeatherForecast[]))]
+   internal partial class AppJsonContext : JsonSerializerContext
+   {
+   }
+   ```
+
+3. 配置 ASP.NET Core 使用该上下文：
+
+   ```csharp
+   builder.Services.ConfigureHttpJsonOptions(options =>
+   {
+       options.SerializerOptions.TypeInfoResolver = AppJsonContext.Default;
+   });
+   ```
+
+如果还会返回其他 `MessageModel<T>` 类型，请同步添加 `Register<T>()` 与 `JsonSerializable`。
+
+可以参考本仓库示例项目`WebAppAotTest`， [AOT 支持文档](https://learn.microsoft.com/zh-cn/dotnet/core/deploying/native-aot/?wt.mc_id=DT-MVP-5005195) 获取更多信息。

--- a/README_CN.md
+++ b/README_CN.md
@@ -53,6 +53,17 @@ public MessageModel<string> Get()
 }
 ```
 
+常用示例：
+
+```csharp
+MessageModel<string>.Error("message required");
+MessageModel<string>.Fail("message required");
+MessageModel<string>.Ok();
+MessageModel<string>.Ok("okk");
+MessageModel<string>.Success("data");
+```
+
+
 分页返回示例：
 
 ```csharp

--- a/Sang.AspNetCore.CommonLibraries.sln
+++ b/Sang.AspNetCore.CommonLibraries.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.9.34616.47
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.11222.15 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sang.AspNetCore.CommonLibraries", "Sang.AspNetCore.CommonLibraries\Sang.AspNetCore.CommonLibraries.csproj", "{E5BBDDC2-3061-446C-ADD7-BAA14F3CC472}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAppTest", "WebAppTest\WebAppTest.csproj", "{DE87C937-B966-4FDB-B00B-D41E94A3647D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebAppAotTest", "WebAppMiniTest\WebAppAotTest.csproj", "{0048730C-5B37-4A70-A6E1-F018CC291D5D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{DE87C937-B966-4FDB-B00B-D41E94A3647D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DE87C937-B966-4FDB-B00B-D41E94A3647D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DE87C937-B966-4FDB-B00B-D41E94A3647D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0048730C-5B37-4A70-A6E1-F018CC291D5D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0048730C-5B37-4A70-A6E1-F018CC291D5D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0048730C-5B37-4A70-A6E1-F018CC291D5D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0048730C-5B37-4A70-A6E1-F018CC291D5D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Sang.AspNetCore.CommonLibraries/Models/MessageModelJsonConverterFactory.cs
+++ b/Sang.AspNetCore.CommonLibraries/Models/MessageModelJsonConverterFactory.cs
@@ -1,10 +1,18 @@
-﻿using System.Text.Json;
+﻿using System.Collections.Concurrent;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Sang.AspNetCore.CommonLibraries.Models
 {
-    internal sealed class MessageModelJsonConverterFactory : JsonConverterFactory
+    public sealed class MessageModelJsonConverterFactory : JsonConverterFactory
     {
+        private static readonly ConcurrentDictionary<Type, JsonConverter> Converters = new();
+
+        public static void Register<T>()
+        {
+            Converters.TryAdd(typeof(MessageModel<T>), new MessageModelJsonConverter<T>());
+        }
+
         public override bool CanConvert(Type typeToConvert)
         {
             return typeToConvert.IsGenericType && typeToConvert.GetGenericTypeDefinition() == typeof(MessageModel<>);
@@ -12,9 +20,12 @@ namespace Sang.AspNetCore.CommonLibraries.Models
 
         public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
         {
-            var dataType = typeToConvert.GetGenericArguments()[0];
-            var converterType = typeof(MessageModelJsonConverter<>).MakeGenericType(dataType);
-            return (JsonConverter)Activator.CreateInstance(converterType)!;
+            if (Converters.TryGetValue(typeToConvert, out var converter))
+            {
+                return converter;
+            }
+
+            throw new NotSupportedException($"MessageModelJsonConverterFactory requires registration for {typeToConvert}.");
         }
     }
 
@@ -39,7 +50,7 @@ namespace Sang.AspNetCore.CommonLibraries.Models
             T? data = default;
             if (root.TryGetProperty("data", out var dataElement) && dataElement.ValueKind != JsonValueKind.Null)
             {
-                data = dataElement.Deserialize<T>(options);
+                data = (T?)dataElement.Deserialize(options.GetTypeInfo(typeof(T)));
             }
 
             string? traceId = null;
@@ -60,7 +71,7 @@ namespace Sang.AspNetCore.CommonLibraries.Models
             if (value.Data is not null)
             {
                 writer.WritePropertyName("data");
-                JsonSerializer.Serialize(writer, value.Data, options);
+                JsonSerializer.Serialize(writer, value.Data, options.GetTypeInfo(typeof(T)));
             }
 
             if (!string.IsNullOrWhiteSpace(value.TraceId))

--- a/Sang.AspNetCore.CommonLibraries/Models/MessageModelJsonConverterFactory.cs
+++ b/Sang.AspNetCore.CommonLibraries/Models/MessageModelJsonConverterFactory.cs
@@ -20,9 +20,25 @@ namespace Sang.AspNetCore.CommonLibraries.Models
 
         public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
         {
+            // 先找手动注册的（AOT 路径）
             if (Converters.TryGetValue(typeToConvert, out var converter))
             {
                 return converter;
+            }
+
+            // 如果没注册，检查是否允许反射（非 AOT 路径）
+            try
+            {
+                var dataType = typeToConvert.GetGenericArguments()[0];
+                var converterType = typeof(MessageModelJsonConverter<>).MakeGenericType(dataType);
+                return (JsonConverter)Activator.CreateInstance(converterType)!;
+            }
+            catch (Exception ex)
+            {
+                //在 AOT 模式下，必须预先调用
+                throw new NotSupportedException("In AOT mode, you must pre-register the MessageModelJsonConverter for the type" +
+                    $" '{typeToConvert.GetGenericArguments()[0].Name}' by calling" +
+                    $" MessageModelJsonConverterFactory.Register<{typeToConvert.GetGenericArguments()[0].Name}>()", ex);
             }
 
             throw new NotSupportedException($"MessageModelJsonConverterFactory requires registration for {typeToConvert}.");

--- a/Sang.AspNetCore.CommonLibraries/Sang.AspNetCore.CommonLibraries.csproj
+++ b/Sang.AspNetCore.CommonLibraries/Sang.AspNetCore.CommonLibraries.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
 	  <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	  <Version>2.0.6</Version>
+	  <Version>2.2.6</Version>
 	  <Authors>SangSQ(桑世强)</Authors>
 	  <Description>AspNet Web CommonLibraries.</Description>
 	  <PackageIcon>ico.png</PackageIcon>

--- a/Sang.AspNetCore.CommonLibraries/Sang.AspNetCore.CommonLibraries.csproj
+++ b/Sang.AspNetCore.CommonLibraries/Sang.AspNetCore.CommonLibraries.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
 	  <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-	  <Version>2.2.6</Version>
+	  <Version>2.2.7</Version>
 	  <Authors>SangSQ(桑世强)</Authors>
 	  <Description>AspNet Web CommonLibraries.</Description>
 	  <PackageIcon>ico.png</PackageIcon>

--- a/WebAppMiniTest/.config/dotnet-tools.json
+++ b/WebAppMiniTest/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "10.0.2",
+      "commands": [
+        "dotnet-ef"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/WebAppMiniTest/Program.cs
+++ b/WebAppMiniTest/Program.cs
@@ -1,0 +1,43 @@
+using Sang.AspNetCore.CommonLibraries.Models;
+using WebAppAotTest;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.TypeInfoResolver = WebAppAotTestJsonContext.Default;
+});
+
+MessageModelJsonConverterFactory.Register<WeatherForecast[]>();
+
+MessageModel<WeatherForecast[]>.StatusFieldName = "code";
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+
+var summaries = new[]
+{
+    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
+};
+
+app.MapGet("/", () =>
+{
+    var forecast = Enumerable.Range(1, 5).Select(index =>
+        new WeatherForecast
+        (
+            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
+            Random.Shared.Next(-20, 55),
+            summaries[Random.Shared.Next(summaries.Length)]
+        ))
+        .ToArray();
+    return MessageModel<WeatherForecast[]>.Ok(forecast);
+});
+
+app.Run();
+
+internal record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+{
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+}

--- a/WebAppMiniTest/Properties/launchSettings.json
+++ b/WebAppMiniTest/Properties/launchSettings.json
@@ -1,0 +1,14 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5242",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/WebAppMiniTest/WebAppAotTest.csproj
+++ b/WebAppMiniTest/WebAppAotTest.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+	  <PublishAot>true</PublishAot>
+  </PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Sang.AspNetCore.CommonLibraries\Sang.AspNetCore.CommonLibraries.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/WebAppMiniTest/WebAppAotTestJsonContext.cs
+++ b/WebAppMiniTest/WebAppAotTestJsonContext.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+using Sang.AspNetCore.CommonLibraries.Models;
+
+namespace WebAppAotTest;
+
+[JsonSerializable(typeof(MessageModel<global::WeatherForecast[]>))]
+[JsonSerializable(typeof(global::WeatherForecast[]))]
+internal partial class WebAppAotTestJsonContext : JsonSerializerContext
+{
+}

--- a/WebAppMiniTest/appsettings.Development.json
+++ b/WebAppMiniTest/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/WebAppMiniTest/appsettings.json
+++ b/WebAppMiniTest/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
This pull request adds support for Native AOT (Ahead-of-Time) publishing for the `MessageModel<T>` type, updates documentation (both English and Chinese) with AOT usage guidance and examples, and introduces a new example project (`WebAppAotTest`) demonstrating AOT configuration. Additionally, the solution and package versioning are updated, and the `MessageModelJsonConverterFactory` is enhanced to support both AOT and non-AOT scenarios.

**AOT (Native) support and example:**

* Added a new example project `WebAppAotTest` (in `WebAppMiniTest/`) with all necessary configuration files (`Program.cs`, `WebAppAotTestJsonContext.cs`, `.csproj`, `appsettings.json`, etc.) to demonstrate Native AOT publishing and correct usage of `MessageModel<T>` with source-generated JSON serialization. [[1]](diffhunk://#diff-be0b43a13beede03d4445526eac2fcc3431b55a46332e10cd3a27028ada20d2aR1-R14) [[2]](diffhunk://#diff-5c0ef9dded55483e22cefc2868114f4bcfb84663c897e85ad88e374aabd1417fR1-R43) [[3]](diffhunk://#diff-cef2205d053ea5cd00c481fffab924bb1ae5b296b4b7d71a9499b3cd10c78155R1-R10) [[4]](diffhunk://#diff-229af09c6d1d3e939290f2dacd74f907a9faf904a9d1016bad591970be294092R1-R9) [[5]](diffhunk://#diff-92d23d409f96387434f256711684117a805916cd7498a33d961a92266364e021R1-R8) [[6]](diffhunk://#diff-63c31fa10512826e7b3d44d8611915c0fba815755e4fd310944b3305e67b7b17R1-R14) [[7]](diffhunk://#diff-20093582d3caf572e810062692ffcb0433ccd63fb4424d2150e280adfc7517bfR1-R13)

* Updated the solution file to include the new `WebAppAotTest` project and updated the Visual Studio version. [[1]](diffhunk://#diff-852c7d5ce11ba3b13a7d9a86ee3634210b20d8049c1c1cc240097a94f2c83ccaL3-R11) [[2]](diffhunk://#diff-852c7d5ce11ba3b13a7d9a86ee3634210b20d8049c1c1cc240097a94f2c83ccaR26-R29)

**Library enhancements for AOT:**

* Made `MessageModelJsonConverterFactory` public, added static registration methods for AOT, and improved converter resolution logic to throw clear errors if registration is missing in AOT scenarios. Serialization/deserialization now uses source-generated type info when available. [[1]](diffhunk://#diff-9dd295cf62494211be4f5905fda5dbf3c244486d3d72b0290058e15df2980dffL1-R45) [[2]](diffhunk://#diff-9dd295cf62494211be4f5905fda5dbf3c244486d3d72b0290058e15df2980dffL42-R69) [[3]](diffhunk://#diff-9dd295cf62494211be4f5905fda5dbf3c244486d3d72b0290058e15df2980dffL63-R90)

* Bumped the package version to `2.2.7` to reflect these changes.

**Documentation updates:**

* Expanded both `README.md` and `README_CN.md` with clear usage examples of `MessageModel<T>` and step-by-step instructions for configuring AOT publishing, including registration of converters and source-generated JSON contexts. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R54-R63) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R195-R227) [[3]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7R56-R66) [[4]](diffhunk://#diff-e6db595f1598cdd1968f25675bddebde43afe7e5a39e0aade96034d51c072ee7R196-R229)

These changes ensure that `MessageModel<T>` works reliably in Native AOT scenarios and provide clear guidance and examples for library consumers.